### PR TITLE
Ensure the ServerFoundCallback is invoked on the main thread & Continue discovery after a server is found 

### DIFF
--- a/NetworkDiscovery.cs
+++ b/NetworkDiscovery.cs
@@ -77,6 +77,9 @@ namespace FishNet.Discovery
 		/// </summary>
 		private HashSet<IPEndPoint> previouslyFoundIPEndPoints = new();
 
+		/// <summary>
+		/// <see cref="SynchronizationContext"/> reference to main thread to ensure the <see cref="ServerFoundCallback"/> is invoked on the main thread.
+		/// </summary>
 		private SynchronizationContext mainThreadSyncContext;
 
 		private void Start()

--- a/README.md
+++ b/README.md
@@ -46,3 +46,7 @@ A very simple LAN network discovery component for Fish-Networking ([Asset Store]
 - [x] Automatically start/stop advertising server
 - [ ] Automatically remove servers that are no longer alive
 - [ ] Introduce Unity coroutines for all `NetworkDiscovery` methods
+
+### Donating
+
+If you found my project helpful, I would greatly appreciate your support through a [donation](https://ko-fi.com/winterboltgames) to help me continue improving and maintaining it!


### PR DESCRIPTION
Currently, when a server is found, the ServerFoundCallback is invoked in the worker thread that was started with the Task.Run() command. Invoking the ServerFoundCallback on the worker thread causes its linked delegates (e.g. ServerFoundCallback += OnServerFound) to also be executed on the worker thread. If the delegate calls ANYTHING related to Unity engine (such as enabling/disabling GameObjects), this either causes an error or your calls to be completely ignored, as Unity hates any code that is not run on the main thread. This commit changes this, and invokes the callback inside the Update() function, which ensures that the callback occurs in the main thread.

I have encountered this issue while I was building my main menu UI for local connections. I wanted to enable a button that would help you connect to the server whenever one was found, however it didn't work. Upon applying the fix on this commit, I was able to get my buttons to enable without a problem.

In addition, previously, the server discovery would instantly stop after a server was found, so if there were more than one server on your network, you were out of luck. This commit also fixes that, and allows the script to discover more than the first server by saving the previously found servers on a list, and then comparing the newly found endpoints to the previous ones to check if they are newly discovered servers.